### PR TITLE
fix: Update main entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "forge-externals-plugin-ts",
   "version": "0.2.3",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
This pull request includes a small update to the `package.json` file to fix the `main` entry point path.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the `main` field from `dist/index.js` to `dist/src/index.js` to correctly reference the entry point of the package.