### PR TITLE
Fix plugin import

### DIFF
--- a/tests/forge.config.js
+++ b/tests/forge.config.js
@@ -1,46 +1,44 @@
-const ForgeExternalsPlugin = require("..");
+const { default: WebpackPlugin } = require('@electron-forge/plugin-webpack');
+const { ForgeExternalsPlugin } = require('..');
 
 module.exports = {
-  packagerConfig: {},
-  makers: [
-    {
-      name: "@electron-forge/maker-squirrel",
-      config: {
-        name: "test_app",
-      },
-    },
-    {
-      name: "@electron-forge/maker-zip",
-      platforms: ["darwin"],
-    },
-    {
-      name: "@electron-forge/maker-deb",
-      config: {},
-    },
-    {
-      name: "@electron-forge/maker-rpm",
-      config: {},
-    },
-  ],
-  plugins: [
-    [
-      "@electron-forge/plugin-webpack",
-      {
-        mainConfig: "./webpack.main.config.js",
-        renderer: {
-          config: "./webpack.renderer.config.js",
-          entryPoints: [
-            {
-              html: "./src/index.html",
-              js: "./src/renderer.ts",
-              name: "main_window",
-            },
-          ],
-        },
-      },
-    ],
-    new ForgeExternalsPlugin({
-      externals: ["native-hello-world"],
-    }),
-  ],
+	packagerConfig: {},
+	makers: [
+		{
+			name: '@electron-forge/maker-squirrel',
+			config: {
+				name: 'test_app',
+			},
+		},
+		{
+			name: '@electron-forge/maker-zip',
+			platforms: ['darwin'],
+		},
+		{
+			name: '@electron-forge/maker-deb',
+			config: {},
+		},
+		{
+			name: '@electron-forge/maker-rpm',
+			config: {},
+		},
+	],
+	plugins: [
+		new WebpackPlugin({
+			mainConfig: './webpack.main.config.js',
+			renderer: {
+				config: './webpack.renderer.config.js',
+				entryPoints: [
+					{
+						html: './src/index.html',
+						js: './src/renderer.ts',
+						name: 'main_window',
+					},
+				],
+			},
+		}),
+		new ForgeExternalsPlugin({
+			externals: ['native-hello-world'],
+		}),
+	],
 };


### PR DESCRIPTION
This pull request updates the `tests/forge.config.js` file to improve consistency and modernize the usage of plugins and configurations. The changes include replacing string literals with single quotes, refactoring plugin initialization, and improving code readability.

### Code consistency and modernization:

* Updated all string literals to use single quotes for consistency across the file.
* Replaced the array-based initialization of `@electron-forge/plugin-webpack` with the `WebpackPlugin` class for a more modern and readable approach.

### Plugin and configuration improvements:

* Updated the initialization of `ForgeExternalsPlugin` to use a more explicit object-based approach.
* Refactored the `renderer` configuration to improve readability by aligning indentation and simplifying the structure.